### PR TITLE
Add hash for GOG Linux version (March 2021)

### DIFF
--- a/web/v1/hashes.json
+++ b/web/v1/hashes.json
@@ -6,5 +6,7 @@
   "78-87-24-5C-9A-40-0A-F0-2B-48-F4-7D-3B-C4-33-3E-64-8B-54-73-20-55-8B-8D-F5-E8-DE-99-E6-43-94-54",
     "-- Steam version (new)",
   "14-B7-7D-28-6D-CB-5B-3B-98-1A-E9-C4-18-9D-23-0D-FF-39-00-6E-45-76-8B-EA-C1-39-F7-4A-FC-FF-9C-D4",
-    "-- Steam version (Jan 2021)"
+    "-- Steam version (Jan 2021)",
+  "D6-D9-04-99-E3-B7-7F-31-4A-A5-3B-72-BD-83-E6-D2-E8-2C-7A-26-2A-FC-39-16-4E-F3-2B-F7-40-26-1D-22",
+    "-- GOG Linux version (Mar 2021)"
 ]


### PR DESCRIPTION
Hi, I bought the GOG Linux version of Shenzhen I/O and wanted to contribute with my hash.

Forgot to create this pull request until now.
However I've not been able to test if the mod works since I've not gotten to that point in the game yet.